### PR TITLE
feat: enable preact devtools for stackman-ui dev builds

### DIFF
--- a/stackman-ui/public/index.tsx
+++ b/stackman-ui/public/index.tsx
@@ -1,3 +1,8 @@
+if (process.env.NODE_ENV === 'development') {
+  // @ts-ignore
+  import("preact/debug");
+}
+
 import { render } from 'preact';
 
 import App from '../src/components/App';


### PR DESCRIPTION
I tested and the bundler doesn't include the devtools in production builds. I've found the browser extension to be pretty useful and this is much better than adding the tools locally and removing them before I make a commit.