### PR TITLE
fix: useSpring in stackman-ui can handle all fields changing now

### DIFF
--- a/stackman-ui/src/hooks/useSpring.ts
+++ b/stackman-ui/src/hooks/useSpring.ts
@@ -8,26 +8,22 @@ const useSpring = (
   damping: number,
   callback: (s: Spring) => void
 ) => {
-  const springRef = useRef<Spring>(
-    new Spring({
-      fromValue: value ? 1 : 0,
-      toValue: value ? 1 : 0,
-      mass,
-      stiffness,
-      damping,
-    })
-  );
+  const springRef = useRef<Spring>(new Spring({ fromValue: value ? 1 : 0 }));
 
   useLayoutEffect(() => {
     callback(springRef.current);
     springRef.current.onUpdate(callback);
 
     return () => springRef.current.removeAllListeners();
-  }, []);
+  }, [callback]);
 
   useEffect(() => {
     springRef.current.updateConfig({ toValue: value ? 1 : 0 }).start();
   }, [value]);
+
+  useEffect(() => {
+    springRef.current.updateConfig({ mass, stiffness, damping });
+  }, [mass, stiffness, damping]);
 };
 
 export default useSpring;


### PR DESCRIPTION
Previously the hook assumed only value can change, but that's not a completely safe assumption. This modifies it to set the spring config in useEffect hooks so the spring config gets updated if any of the props change. This also accounts for changing the callback, even if there's no real reason to expect someone to do that.