### PR TITLE
ci: store derivations on cachix

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v18
 
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v11
+        with:
+          name: wuvt
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Build Docker image
         run: nix build .#stackman-container
 


### PR DESCRIPTION
Caching should generally speed up builds, especially when something is merged and master has to be rebuilt.