### PR TITLE
fix: remove stackman-ui-prototype from container image

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674868155,
-        "narHash": "sha256-eFNm2h6fNbgD7ZpO4MHikCB5pSnCJ7DTmwPisjetmwc=",
+        "lastModified": 1677075010,
+        "narHash": "sha256-X+UmR1AkdR//lPVcShmLy8p1n857IGf7y+cyCArp8bU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce20e9ebe1903ea2ba1ab006ec63093020c761cb",
+        "rev": "c95bf18beba4290af25c60cbaaceea1110d0f727",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
             config = {
               Cmd = [
                 "${pkgs.stackman-api-demo}/bin/stackman-api-demo"
-                "-s" "${pkgs.stackman-ui-prototype}"
                 "-a" "/data/albums.json"
               ];
               User = "stackman";


### PR DESCRIPTION
The recent API changes broke it. I've tagged an old commit as 0.0.1-prototype so we still have a working container for the prototype.