### PR TITLE
chore: run ci on git tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: [master, staging, trying]
+    tags: '*'
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
For when we eventually start tagging releases.